### PR TITLE
Change result rendering order

### DIFF
--- a/app/views/nexaas/async/collector/async_resource/show.js.erb
+++ b/app/views/nexaas/async/collector/async_resource/show.js.erb
@@ -1,5 +1,5 @@
 <% if @result.content_is_ready? %>
-  $('#js-nexaas-async-collector').parent().append("<%= escape_javascript(@result.content.html_safe) %>");
-  $('.nexaas-async-collector-loading').remove();
   clearInterval(window.nexaas_async_interval);
+  $('.nexaas-async-collector-loading').remove();
+  $('#js-nexaas-async-collector').parent().append("<%= escape_javascript(@result.content.html_safe) %>");
 <% end %>


### PR DESCRIPTION
This is needed because if my result content has a `window.print()`, for example, when result is rendered the loading was not removed from the page yet and it will be shown on the printed page.