### PR TITLE
Use sidekiq redis connection pool to get/set data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     nexaas-async-collector (1.2.1)
       rails (>= 3.2)
-      redis-namespace (>= 1.5.2)
       sidekiq (~> 4.2)
 
 GEM
@@ -105,8 +104,6 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
     redis (3.3.3)
-    redis-namespace (1.5.2)
-      redis (~> 3.0, >= 3.0.4)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)

--- a/lib/nexaas/async/collector.rb
+++ b/lib/nexaas/async/collector.rb
@@ -1,4 +1,3 @@
-require 'redis-namespace'
 require 'sidekiq'
 require "nexaas/async/collector/engine"
 require "nexaas/async/collector/in_memory_storage"

--- a/lib/nexaas/async/collector/in_memory_storage.rb
+++ b/lib/nexaas/async/collector/in_memory_storage.rb
@@ -5,13 +5,13 @@ module Nexaas
 
         def get(key)
           Sidekiq.redis_pool.with do |connection|
-            connection.get(namespace_key(key))
+            connection.get(namespaced_key(key))
           end
         end
 
         def set(key, value, expiration=nil)
           Sidekiq.redis_pool.with do |connection|
-            key = namespace_key(key)
+            key = namespaced_key(key)
             connection.set(key, value)
             connection.expire(key, expiration) if expiration
           end
@@ -19,7 +19,7 @@ module Nexaas
 
         private
 
-        def namespace_key(key)
+        def namespaced_key(key)
           "#{redis_namespace}:#{key}"
         end
 

--- a/nexaas-async-collector.gemspec
+++ b/nexaas-async-collector.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 3.2"
   s.add_dependency "sidekiq", "~> 4.2"
-  s.add_dependency "redis-namespace", ">= 1.5.2"
 
   s.add_development_dependency "rspec", "3.6.0"
   s.add_development_dependency "rspec-rails", "3.6.0"

--- a/spec/lib/nexaas/async/collector/in_memory_storage_spec.rb
+++ b/spec/lib/nexaas/async/collector/in_memory_storage_spec.rb
@@ -1,11 +1,15 @@
 require "rails_helper"
 
 describe Nexaas::Async::Collector::InMemoryStorage do
-  let(:redis) { Redis.new }
   subject { described_class.new }
 
   describe "#get" do
     before { subject.set("foo", "bar") }
+
+    it 'uses sidekiq shared redis pool' do
+      expect(Sidekiq).to receive(:redis_pool).and_call_original
+      subject.get("foo")
+    end
 
     it 'gets value from redis' do
       expect(subject.get("foo")).to eq("bar")
@@ -13,6 +17,11 @@ describe Nexaas::Async::Collector::InMemoryStorage do
   end
 
   describe "#set" do
+    it 'uses sidekiq shared redis pool' do
+      expect(Sidekiq).to receive(:redis_pool).and_call_original
+      subject.set("foo", "bar")
+    end
+
     it 'writes data in redis' do
       subject.set("foo", "land")
       expect(subject.get("foo")).to eq("land")


### PR DESCRIPTION
## Description

This PR fixes the problem of opening multiple connections with Redis, and then hitting the maximum number of allowed connections on the server, when lots of users request data at the same time.

## Related bug

`Redis::CommandError: ERR max number of clients reached` exception is raised when multiple users use `nexaas-async-collect` helper (this means multiple opened connections with redis).
