### PR TITLE
Fix bug when trying to download data through browser

### DIFF
--- a/app/views/nexaas/async/collector/async_resource/show.js.erb
+++ b/app/views/nexaas/async/collector/async_resource/show.js.erb
@@ -3,7 +3,7 @@
 
   <% if @result.is_file? %>
     $('#js-nexaas-async-collector-loading-<%= @unique_id %>').remove();
-    window.location.href = '<%= async_resource_path(params[:id], format: @result.extension) %>';
+    window.location.href = '<%= nexaas_async_collector.async_resource_path(params[:id], format: @result.extension) %>';
   <% else %>
     $('#js-nexaas-async-collector-loading-<%= @unique_id %>').remove();
     $('#js-nexaas-async-collector-<%= @unique_id %>').parent().append("<%= escape_javascript(@result.content.force_encoding('UTF-8').html_safe) %>");


### PR DESCRIPTION
When trying to generate and download data using `send_data`, the script to request data to gem routes was no using `nexaas-async-collector` routes interface. So, it was showing the message `DEPRECATION WARNING: You are trying to generate the URL for a named route called "async_resource" but no such route was found. In the future, this will result in an 'ActionController::UrlGenerationError' exception.`

After that, the JS was requesting to `/nexaas_async_collect/assets?action=show&amp;controller=nexaas%2Fasync%2Fcollector%2Fasync_resource&amp;format=xls&amp;id=ad29dbca96422413c7677028e9b8eb` which will respond with a 404.