### PR TITLE
Clear interval when rendering loading and the interval already exists

### DIFF
--- a/app/views/nexaas/async/collector/async_resource/_show.html.erb
+++ b/app/views/nexaas/async/collector/async_resource/_show.html.erb
@@ -1,4 +1,7 @@
 <script type="text/javascript" id="js-nexaas-async-collector-<%= unique_id %>">
+  if (!!window.nexaas_async_interval)
+    clearInterval(window.nexaas_async_interval);
+
   var requestContent = function() {
     $.ajax({
       url: '<%= nexaas_async_collector.async_resource_path(collect_id) %>',


### PR DESCRIPTION
If we render the loading partial to a modal and open/close the modal several times, some JavaScript interval IDs will be lost and the data will appear several times (or download the file several times).

To avoid that, we have to clear the interval, it it already exists, when showing the loading page with the script to request data.